### PR TITLE
Simplify shape unmarshalling

### DIFF
--- a/pkg/raytracing/object/box.go
+++ b/pkg/raytracing/object/box.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"encoding/json"
 	"math"
 
 	"github.com/BrendanBurkhart/raytracer/pkg/raytracing"
@@ -13,6 +14,15 @@ type Box struct {
 	MaxCorner raytracing.Vector `json:"maxCorner"`
 	center    raytracing.Vector
 	extent    raytracing.Vector
+}
+
+func boxFactory(data *json.RawMessage) (Object, error) {
+	obj := Box{}
+	if err := json.Unmarshal(*data, &obj); err != nil {
+		return obj, err
+	}
+	obj.Initialize()
+	return obj, nil
 }
 
 // Initialize performs precomputation and preprocessing

--- a/pkg/raytracing/object/object.go
+++ b/pkg/raytracing/object/object.go
@@ -69,7 +69,7 @@ func findObjectFactory(typing map[string]*json.RawMessage) (factory objectFactor
 
 	var shapeType string
 	if err = json.Unmarshal(*rawShapeType, &shapeType); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error unmarshalling shape type to string: %v", err)
 	}
 
 	factory, ok = objectFactoryMap[shapeType]

--- a/pkg/raytracing/object/object.go
+++ b/pkg/raytracing/object/object.go
@@ -48,8 +48,6 @@ func (jsonObjects *JSONObjects) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	*jsonObjects = append(*jsonObjects)
-
 	for i, typing := range typingData {
 		obj, err := unmarshalObject(typing, rawObjects[i])
 		if err != nil {

--- a/pkg/raytracing/object/object.go
+++ b/pkg/raytracing/object/object.go
@@ -24,7 +24,14 @@ func (om *Material) MaterialID() int {
 	return om.Material
 }
 
-// Custom JSON unmarshalling to handle different implements of the Object interface
+// shapeUnmarshaller unmarshals JSON data into a specific implementation of Object
+type objectFactory func(*json.RawMessage) (Object, error)
+
+var objectFactoryMap = map[string]objectFactory{
+	"plane":  planeFactory,
+	"sphere": sphereFactory,
+	"box":    boxFactory,
+}
 
 // JSONObjects is a named type to allow a slice of interfaces to have custom JSON unmarshalling
 type JSONObjects []Object
@@ -36,14 +43,14 @@ func (jsonObjects *JSONObjects) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	var types []map[string]*json.RawMessage
-	if err := json.Unmarshal(b, &types); err != nil {
+	var typingData []map[string]*json.RawMessage
+	if err := json.Unmarshal(b, &typingData); err != nil {
 		return err
 	}
 
 	*jsonObjects = append(*jsonObjects)
 
-	for i, typing := range types {
+	for i, typing := range typingData {
 		obj, err := unmarshalObject(typing, rawObjects[i])
 		if err != nil {
 			return err
@@ -53,39 +60,37 @@ func (jsonObjects *JSONObjects) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// findObjectFactory returns the correct factory function for shape primitive (Object) based on its typing data
+func findObjectFactory(typing map[string]*json.RawMessage) (factory objectFactory, err error) {
+	rawShapeType, ok := typing["type"]
+	if !ok {
+		return nil, fmt.Errorf("JSON object does not contain key 'type' needed to unmarshal it")
+	}
+
+	var shapeType string
+	if err = json.Unmarshal(*rawShapeType, &shapeType); err != nil {
+		return nil, err
+	}
+
+	factory, ok = objectFactoryMap[shapeType]
+	if !ok {
+		return nil, fmt.Errorf("cannot find object type %s referenced in JSON data", shapeType)
+	}
+	return factory, nil
+}
+
 // unmarshalObject unmarshals the data into a struct implementing Object and returns it as an Object
 func unmarshalObject(typing map[string]*json.RawMessage, data *json.RawMessage) (Object, error) {
-	for key, value := range typing {
-		if key == "type" {
-			var shapeType string
-			if err := json.Unmarshal(*value, &shapeType); err != nil {
-				return nil, err
-			}
-			switch shapeType {
-			case "sphere":
-				obj := Sphere{}
-				if err := json.Unmarshal(*data, &obj); err != nil {
-					return nil, err
-				}
-				return obj, nil
-			case "plane":
-				obj := Plane{}
-				if err := json.Unmarshal(*data, &obj); err != nil {
-					return nil, err
-				}
-				obj.Normalize()
-				return obj, nil
-			case "box":
-				obj := Box{}
-				if err := json.Unmarshal(*data, &obj); err != nil {
-					return nil, err
-				}
-				obj.Initialize()
-				return obj, nil
-			default:
-				return nil, fmt.Errorf("cannot find object type %s referenced in json data", shapeType)
-			}
-		}
+	factory, err := findObjectFactory(typing)
+	if err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("JSON object does not contain key 'type' needed to unmarshal it")
+
+	var obj Object
+	obj, err = factory(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
 }

--- a/pkg/raytracing/object/plane.go
+++ b/pkg/raytracing/object/plane.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"encoding/json"
 	"math"
 
 	"github.com/BrendanBurkhart/raytracer/pkg/raytracing"
@@ -11,6 +12,15 @@ type Plane struct {
 	*Material
 	Normal raytracing.Vector `json:"normal"`
 	Point  raytracing.Vector `json:"point"`
+}
+
+func planeFactory(data *json.RawMessage) (Object, error) {
+	obj := Plane{}
+	if err := json.Unmarshal(*data, &obj); err != nil {
+		return obj, err
+	}
+	obj.Normalize()
+	return obj, nil
 }
 
 // Intersect returns whether there is an intersection with r within maxRange,

--- a/pkg/raytracing/object/sphere.go
+++ b/pkg/raytracing/object/sphere.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"encoding/json"
 	"math"
 
 	"github.com/BrendanBurkhart/raytracer/pkg/raytracing"
@@ -11,6 +12,12 @@ type Sphere struct {
 	*Material
 	Radius float64           `json:"radius"`
 	Center raytracing.Vector `json:"center"`
+}
+
+func sphereFactory(data *json.RawMessage) (Object, error) {
+	obj := Sphere{}
+	err := json.Unmarshal(*data, &obj)
+	return obj, err
 }
 
 // Intersect returns whether there is an intersection with r within maxRange,


### PR DESCRIPTION
Shape primitive unmarshalling was done via a switch statement, one case per type of shape. I replaced the switch with a map containing shape factory functions which can produce a shape object from raw JSON.