### PR TITLE
Make lighting model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Renders large/complicated scenes quickly using goroutines. Supports orthographic
 
 I currently only support materials, not rendering textures or UV mapping. Additionally, only planes, spheres and boxes are supported. I may add support for UV mapping and more complex/custom shapes eventually.
 
-Both Lambert and Phong lighting are supported, and both work with reflections and shadows. Refraction is not currently available.
+Both Lambertian and Phong lighting models are supported, and both work with reflections and shadows. Refraction is not currently available.
 
 I added simple configurable anti-aliasing through super sampling.
 
@@ -34,9 +34,11 @@ Scenes are described using JSON files in the following format:
     "target": Vector, specifies where the camera is pointed,
     "roll": Camera roll in degrees, positive is counter-clockwise when facing the same direction as the camera,
 
-    "antiAliasingFactor": Super samples per pixel, must be at least 1. Optional,
+    "antiAliasingFactor": Super samples per pixel, must be at least 1. Optional, default is 1,
+    "lightingModel": One of "lambertian", or "phong". Optional, default is "phong",
 
-    "projection": Projection type - one of "perspective", "orthographic" or "fisheye",
+    "projection": Projection type - one of "perspective", "orthographic", or "fisheye",
+
     "viewWidth": If using an orthographic projection, viewWidth must be specified. It is the view width of the rendered image in in-scene units. Can be used with a perspective projection, in which case focalLength must be specified.
     "hfov": If using a fisheye projection, hfov must be specified. It is the horizontal field of view in degrees. Can optionally replace viewWidth for a perspective projection.
     "focalLength": For perspective projection, distances from origin to render-plane. If this is not specified, opticalRadius must be.

--- a/internal/scene/scene.go
+++ b/internal/scene/scene.go
@@ -76,7 +76,7 @@ func (s *Scene) FindIntersection(r raytracing.Ray) (bool, float64, int) {
 }
 
 // TraceRay traces a given ray to its first intersection and performs lighting calculations
-func (s *Scene) TraceRay(r raytracing.Ray, lightStrength float64, remainingDepth int) (color raytracing.Color) {
+func (s *Scene) TraceRay(r raytracing.Ray, lightStrength float64, remainingDepth int, lighting raytracing.LightingModel) (color raytracing.Color) {
 	intersected, t, currentObject := s.FindIntersection(r)
 
 	if !intersected {
@@ -110,7 +110,7 @@ func (s *Scene) TraceRay(r raytracing.Ray, lightStrength float64, remainingDepth
 		}
 	}
 
-	surfaceColor := raytracing.PhongReflectance(visibleLights, s.ambientLight, viewer, intersection, normal, material)
+	surfaceColor := lighting(visibleLights, s.ambientLight, viewer, intersection, normal, material)
 	color.Red += surfaceColor.Red * lightStrength
 	color.Green += surfaceColor.Green * lightStrength
 	color.Blue += surfaceColor.Blue * lightStrength
@@ -122,7 +122,7 @@ func (s *Scene) TraceRay(r raytracing.Ray, lightStrength float64, remainingDepth
 
 	var reflectedColor raytracing.Color
 	if remainingDepth > 0 {
-		reflectedColor = s.TraceRay(r, lightStrength*material.Reflectance, remainingDepth-1)
+		reflectedColor = s.TraceRay(r, lightStrength*material.Reflectance, remainingDepth-1, lighting)
 	}
 
 	color.Red = color.Red + reflectedColor.Red

--- a/pkg/raytracing/lighting.go
+++ b/pkg/raytracing/lighting.go
@@ -34,8 +34,13 @@ type Light struct {
 	Ambient  Color  `json:"ambient"`
 }
 
-// LambertianReflectance calculates the Lambertian reflectance model. The surface normal should be normalized.
-func LambertianReflectance(lights []Light, position Vector, normal Vector, material Material) (color Color) {
+// LightingModel is a function type that takes information about a location,
+// calculates lighting using a specific lighitng model and returns a color for
+// that location. The surface normal vector should be normalized.
+type LightingModel func(lights []Light, ambientLight Color, viewer Vector, position Vector, normal Vector, material Material) (color Color)
+
+// LambertianLighting calculates the Lambertian lighting model. The surface normal vector should be normalized.
+func LambertianLighting(lights []Light, _ Color, _ Vector, position Vector, normal Vector, material Material) (color Color) {
 	for _, light := range lights {
 		dist := light.Position.Subtract(position)
 
@@ -50,7 +55,7 @@ func LambertianReflectance(lights []Light, position Vector, normal Vector, mater
 			continue
 		}
 
-		// Lambert diffusion
+		// Lambertian diffusion
 		surfaceLightLevel := lightVec.Dot(normal)
 		color.Red += surfaceLightLevel * light.Diffuse.Red * material.Diffuse.Red
 		color.Green += surfaceLightLevel * light.Diffuse.Green * material.Diffuse.Green
@@ -59,8 +64,8 @@ func LambertianReflectance(lights []Light, position Vector, normal Vector, mater
 	return
 }
 
-// PhongReflectance calculates the Phong reflectance model. The surface normal should be normalized.
-func PhongReflectance(lights []Light, ambientLight Color, viewer Vector, position Vector, normal Vector, material Material) (color Color) {
+// PhongLighting calculates the Phong lighting model. The surface normal vector should be normalized.
+func PhongLighting(lights []Light, ambientLight Color, viewer Vector, position Vector, normal Vector, material Material) (color Color) {
 	for _, light := range lights {
 		dist := light.Position.Subtract(position)
 


### PR DESCRIPTION
Lighting model can be specified in scene data file. The options are currently Lambertian or Phong lighting, with Phong as the default.